### PR TITLE
Minimal changes to work with new AFDKO and glyph data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ dump.tar.gz
 dump_newest_only.txt
 dump_all_versions.txt
 GlyphWiki-UTF*
-HalfWidthGlyphs.txt
 Blocks.txt
 gw-list.wiki
+HalfwidthGlyphs-BMP.txt
+HalfwidthGlyphs-nonUCS.txt
+HalfwidthGlyphs-SMP.txt
+NonSpacingGlyphs-Halfwidth.txt

--- a/Makefile_HanaMin
+++ b/Makefile_HanaMin
@@ -21,8 +21,14 @@ work	= ./$(BASE).work
 dump.tar.gz:
 	wget http://glyphwiki.org/dump.tar.gz
 
-HalfwidthGlyphs.txt:
-	wget -O HalfwidthGlyphs.txt 'http://glyphwiki.org/get_source.cgi?name=Group:HalfwidthGlyphs'
+HalfwidthGlyphs-BMP.txt:
+	wget -O HalfwidthGlyphs-BMP.txt 'http://glyphwiki.org/get_source.cgi?name=Group:HalfwidthGlyphs-BMP'
+
+HalfwidthGlyphs-SMP.txt:
+	wget -O HalfwidthGlyphs-SMP.txt 'http://glyphwiki.org/get_source.cgi?name=Group:HalfwidthGlyphs-SMP'
+
+HalfwidthGlyphs-nonUCS.txt:
+	wget -O HalfwidthGlyphs-nonUCS.txt 'http://glyphwiki.org/get_source.cgi?name=Group:HalfwidthGlyphs-nonUCS'
 
 NonSpacingGlyphs-Halfwidth.txt:
 	wget -O NonSpacingGlyphs-Halfwidth.txt 'http://glyphwiki.org/get_source.cgi?name=Group:NonSpacingGlyphs-Halfwidth'
@@ -55,7 +61,7 @@ $(BASE).svg: $(BASE).source
 	for file in $(work)/*.svg; do $(PERL) unionpoly.pl $$file; done
 	$(PERL) $(PROG)/makeSVGFont.pl $(BASE) >$(BASE).log 2>$(BASE).err
 
-$(BASE).pfa: $(BASE).svg HalfwidthGlyphs.txt NonSpacingGlyphs-Halfwidth.txt
+$(BASE).pfa: $(BASE).svg HalfwidthGlyphs-BMP.txt HalfwidthGlyphs-SMP.txt HalfwidthGlyphs-nonUCS.txt NonSpacingGlyphs-Halfwidth.txt
 	ruby makeSVG-half.rb $(BASE).svg $(BASE).map
 	tx -t1 $(BASE).svg $(BASE).pfa >>$(BASE).log 2>>$(BASE).err
 
@@ -70,12 +76,12 @@ $(BASE).cmap $(BASE).ivs $(BASE).cidmap $(BASE).features $(BASE).html: $(BASE).m
 	mv $(BASE).tmp.cmap $(BASE).cmap
 
 $(BASE).raw: $(BASE).cidinfo $(BASE).cidmap $(BASE).pfa
-	mergeFonts -cid $(BASE).cidinfo $(BASE).raw $(BASE).cidmap $(BASE).pfa >>$(BASE).log 2>>$(BASE).err
+	mergefonts -cid $(BASE).cidinfo $(BASE).raw $(BASE).cidmap $(BASE).pfa >>$(BASE).log 2>>$(BASE).err
 #	checkOutlines -e -k -O -x $(BASE).pfa >/dev/null 2>>$(BASE).err
 
 $(BASE).hinted.raw: $(BASE).raw
 	$(PERL) $(SCRIPTS)/hintcidfont.pl $(PROG)/hintparam.txt < $(BASE).raw > $(BASE).hinted.raw
-	autohint -r -q $(BASE).hinted.raw >>$(BASE).log 2>>$(BASE).err
+	psautohint $(BASE).hinted.raw >>$(BASE).log 2>>$(BASE).err
 
 $(BASE).otf: $(BASE).fmndb $(BASE).ivs $(BASE).cmap $(BASE).hinted.raw $(BASE).features
 	makeotf $(subrtnz) -newNameID4 -mf $(BASE).fmndb -cs 1 -ci	\

--- a/gw-list.el
+++ b/gw-list.el
@@ -108,7 +108,7 @@
     ("Katakana Phonetic Extensions" "Y" nil nil nil "X" "X" nil nil)
     ("Enclosed CJK Letters and Months" "Y" nil nil nil "X" "X" nil nil)
     ("CJK Compatibility" "Y" nil nil nil "X" "X" nil nil)
-    ("CJK Unified Ideographs Extension A" "Y" nil nil nil nil "X" nil nil)
+    ("CJK Unified Ideographs Extension A" nil "Y" nil nil nil "X" nil nil)
     ("Yijing Hexagram Symbols" "Y" nil nil nil nil "X" nil nil)
     ("CJK Unified Ideographs" "Y" nil nil nil "X" nil nil nil)
     ("Cyrillic Extended-B" "Y" nil nil nil nil "X" nil nil)

--- a/makeSVG-half.rb
+++ b/makeSVG-half.rb
@@ -6,7 +6,15 @@ require 'tempfile'
 $hash = Hash.new(nil)
 
 def load_hwg_data ()
-  File.open("HalfwidthGlyphs.txt", :encoding => "UTF-8").each do |line|
+  File.open("HalfwidthGlyphs-BMP.txt", :encoding => "UTF-8").each do |line|
+    line.scan(/\[\[(.+?)\]\]/) {|gwname|
+      $hash[gwname[0]]=true}
+  end
+  File.open("HalfwidthGlyphs-SMP.txt", :encoding => "UTF-8").each do |line|
+    line.scan(/\[\[(.+?)\]\]/) {|gwname|
+      $hash[gwname[0]]=true}
+  end
+  File.open("HalfwidthGlyphs-nonUCS.txt", :encoding => "UTF-8").each do |line|
     line.scan(/\[\[(.+?)\]\]/) {|gwname|
       $hash[gwname[0]]=true}
   end


### PR DESCRIPTION
The purpose of this PR is to allow the project to build with the latest version of AFDKO as well as GlyphWiki data.

There are a number of new glyphs (I believe mostly non-kanji) in the GlyphWiki data, causing the previous HanaMinA to exceed the 64k glyph limit. I handled this by moving Extension A characters to HanaMinB. Of course other solutions are possible.

Note that the options for (ps)autohint changed significantly [here](https://github.com/adobe-type-tools/psautohint/pull/43). I believe that the new `psautohint` is equivalent to the old `autohint -q -r`, but I am not completely sure, particularly for the new hint overwriting logic.