### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:focal
+
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  git python3.8 wget build-essential emacs ruby rhino python3-pip
+RUN pip3 install afdko
+RUN PERL_MM_USE_DEFAULT=1 cpan App::cpanminus
+RUN cpanm Math::Clipper
+RUN git clone https://github.com/adobe-type-tools/perl-scripts.git /opt/perl-scripts

--- a/Makefile_HanaMin
+++ b/Makefile_HanaMin
@@ -2,7 +2,7 @@
 
 PROG	= .
 PERL    = perl
-SCRIPTS = $(HOME)/.ghq/github.com/adobe-type-tools/perl-scripts
+SCRIPTS = /opt/perl-scripts
 PS2PDF  = ps2pdf
 version = $(shell date "+%y.%j")
 sub	= A

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ These fonts also cover all variants of
 
 Run the following command to create the newest font. Please make sure
 that you install all required software, set up Perl library environment
-variables, set the $(AFDKO) environment variable to the installation
+variables, set the $(SCRIPTS) variable to the installation
 directory of AFDKO perl scripts.
 
     git clone http://github.com/kawabata/glyphwiki-afdko
@@ -86,6 +86,16 @@ directory of AFDKO perl scripts.
     git submodule update
     «check Makefile/Makefile_HanaMin settings»
     make
+
+You can also build in a Docker container to make it easier to install
+the dependencies like this:
+
+    git clone http://github.com/kawabata/glyphwiki-afdko
+    cd glyphwiki-afdko
+    git submodule init
+    git submodule update
+    docker build -t gw-afdko .
+    docker run -v "$PWD:/code" -w /code gw-afdko make
 
 This will download "dump.tar.gz" from GlyphWiki web site and create
 the fonts. It may take several hours (depends on your machine power),


### PR DESCRIPTION
Since there are a number of dependencies for running the build process, I thought it might be useful to provide a Dockerfile to make it easier to build. This could also be useful to make a Docker image for automated builds run on something like CircleCI or GitHub Actions.